### PR TITLE
Issue #10: Implement an `AMQPTimeout` directive, for configuring the …

### DIFF
--- a/mod_amqp.h.in
+++ b/mod_amqp.h.in
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_amqp
- * Copyright (c) 2017 TJ Saunders
+ * Copyright (c) 2017-2022 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -34,7 +34,7 @@
 # include <sys/mman.h>
 #endif
 
-#define MOD_AMQP_VERSION	"mod_amqp/0.0"
+#define MOD_AMQP_VERSION	"mod_amqp/0.1"
 
 /* Make sure the version of proftpd is as necessary. */
 #if PROFTPD_VERSION_NUMBER < 0x0001030701

--- a/mod_amqp.html
+++ b/mod_amqp.html
@@ -45,6 +45,7 @@ questions, concerns, or suggestions regarding this module.
   <li><a href="#AMQMessageType">AMQPMessageType</a>
   <li><a href="#AMQPOptions">AMQPOptions</a>
   <li><a href="#AMQPServer">AMQPServer</a>
+  <li><a href="#AMQPTimeout">AMQPTimeout</a>
 </ul>
 
 <p>
@@ -286,6 +287,21 @@ Finally, for testing purposes, you can tell <code>mod_amqp</code> to
 </pre>
 This is <b>not recommended</b>, as it leaves the connection with the AMQP
 server open to <i>man-in-the-middle</i> (MITM) attacks.
+
+<p>
+<hr>
+<h3><a name="AMQPTimeout">AMQPTimeout</a></h3>
+<strong>Syntax:</strong> AMQPTimeout <em>connect-milliseconds</em><br>
+<strong>Default:</strong> 2000<br>
+<strong>Context:</strong> server config, <code>&lt;VirtualHost&gt;</code>, <code>&lt;Global&gt;</code><br>
+<strong>Module:</strong> mod_amqp<br>
+<strong>Compatibility:</strong> 1.3.6rc5 and later
+
+<p>
+The <code>AMQPTimeout</code> directive configures the maximum number of
+milliseconds for <code>mod_amqp</code> to connect to the
+<a href="#AMQPServer"><code>AMQPServer</code></a>.  The default is 2000ms
+(2 seconds).
 
 <p>
 <hr>
@@ -594,7 +610,7 @@ matters are the <code>LogFormat</code> variables which appear in the directive.
 <p>
 <hr>
 <font size=2><b><i>
-&copy; Copyright 2017 TJ Saunders<br>
+&copy; Copyright 2017-2022 TJ Saunders<br>
  All Rights Reserved<br>
 </i></b></font>
 <hr>


### PR DESCRIPTION
…connect timeout.

This leaves room for setting timeouts for other operations, such as I/O, as well.